### PR TITLE
Compatibility with float percentages

### DIFF
--- a/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
+++ b/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
@@ -166,9 +166,9 @@ public class RolloutZKClient implements RolloutClient {
             }
             int percentage = 0;
             try {
-                percentage = Integer.parseInt(splitResult[0]);
+                percentage = (int) Double.parseDouble(splitResult[0]);
             } catch (NumberFormatException ex) {
-                log.warn("Couldn't parse `{}` as a long, ignoring percentage for key `{}`", splitResult[0], key);
+                log.warn("Couldn't parse `{}` as a double, ignoring percentage for key `{}`", splitResult[0], key);
             }
             final List<String> groups = Arrays.asList(splitResult[2].split(","));
             final List<Long> userIds = new ArrayList<Long>();

--- a/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
+++ b/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
@@ -2,6 +2,7 @@ package com.librato.rollout.zk;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.librato.rollout.RolloutClient;
@@ -43,6 +44,7 @@ public class RolloutZKClient implements RolloutClient {
         this.framework = framework;
         this.rolloutPath = rolloutPath;
         this.listener = new CuratorListener() {
+            @SuppressWarnings("ThrowFromFinallyBlock")
             @Override
             public void eventReceived(CuratorFramework client, CuratorEvent event) throws Exception {
                 if (framework.getState() != CuratorFrameworkState.STARTED ||
@@ -57,7 +59,12 @@ public class RolloutZKClient implements RolloutClient {
                     log.error("Error on event update", ex);
                 } finally {
                     // Set the watch just in case it was simply bad data
-                    setWatch();
+                    try {
+                        setWatch();
+                    } catch (Exception e) {
+                        log.error("Could not set watch", e);
+                        throw Throwables.propagate(e);
+                    }
                 }
             }
         };

--- a/src/test/java/com/librato/rollout/RolloutZKClientTest.java
+++ b/src/test/java/com/librato/rollout/RolloutZKClientTest.java
@@ -120,7 +120,7 @@ public class RolloutZKClientTest {
             client.start();
 
             assertFalse(client.userFeatureActive("nosuchfeature", 1, Lists.newArrayList("foo")));
-            framework.setData().forPath(rolloutPath, "{\"feature:hello\": \"25||\"}".getBytes());
+            framework.setData().forPath(rolloutPath, "{\"feature:hello\": \"25.0||\"}".getBytes());
             Thread.sleep(100);
             assertTrue(client.userFeatureActive("hello", 100, Lists.newArrayList("foo")));
             assertTrue(client.userFeatureActive("hello", -100, Lists.newArrayList("foo")));


### PR DESCRIPTION
This parses the incoming percentage as a double but casts to an int.  This solves a compatibility problem with later versions of the rollout ruby gem which use floats for percentages.  Later we may decide to just use doubles for percents within this code.

cc @mheffner 