### PR TITLE
Adding a start()-time test for the ZK rollout path

### DIFF
--- a/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
+++ b/src/main/java/com/librato/rollout/zk/RolloutZKClient.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Iterables;
 import com.librato.rollout.RolloutClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.slf4j.Logger;
@@ -104,6 +105,10 @@ public class RolloutZKClient implements RolloutClient {
     }
 
     private void build() throws IOException {
+        final ChildData childs = this.nodeCache.getCurrentData();
+        if (childs == null) {
+            throw new IOException("Rollout wasn't set up correctly. Make sure your zk rollout path (e.g., '/rollout/users') exists in zookeeper");
+        }
         features.set(ImmutableMap.copyOf(parseData(nodeCache.getCurrentData().getData())));
     }
 

--- a/src/test/java/com/librato/rollout/BadSystemRolloutZKClientTest.java
+++ b/src/test/java/com/librato/rollout/BadSystemRolloutZKClientTest.java
@@ -1,0 +1,35 @@
+package com.librato.rollout;
+
+import com.librato.rollout.zk.RolloutZKClient;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class BadSystemRolloutZKClientTest {
+
+    private static final String rolloutPath = "/rollout-test-node";
+    private static CuratorFramework framework;
+
+    @BeforeClass
+    public static void classSetup() {
+        framework = CuratorFrameworkFactory.builder()
+                .connectString("localhost:2181")
+                .retryPolicy(new RetryNTimes(1, 100))
+                .build();
+        framework.start();
+    }
+
+    // This does what the main test class does, but doesn't do the @BeforeClass setup
+    // first -- easier by far than doing 'interesting' things over there
+
+    @Test(expected = IOException.class)
+    public void explodesOnNoZKPath() throws Exception {
+        final RolloutClient client = new RolloutZKClient(framework, rolloutPath);
+        client.start();
+    }
+
+}


### PR DESCRIPTION
If the rollout path in ZK isn't set, `NodeCache.getCurrentData()` can return null, which leads to a hard-to-diagnose NPE. This tests for a null return and throws IOE if it's not set.